### PR TITLE
Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: pip
 
 python:
  - pypy
- - pypy3
+ - pypy-3.8
  - 3.6
  - 2.7
  - 3.5


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos